### PR TITLE
Remove unnecessary prefix when logging to stdout

### DIFF
--- a/src/subprocess_runner.py
+++ b/src/subprocess_runner.py
@@ -38,7 +38,7 @@ class SubprocessRunner:
         if process.stdout:
             for line in iter(process.stdout.readline, ""):
                 stdout_lines.append(line.strip())
-                logging.info("Command output: %s", line.strip())
+                logging.info(line.strip())
             process.stdout.close()
         stderr_thread.join()
 


### PR DESCRIPTION
Changes:

- Remove unnecessary prefix when logging to stdout

---

This will make logs more readable in Keboola. Before, every line was prefixed with "Command output: "