### PR TITLE
venv defaults to "" instead of null due to nulls being removed in KDP

### DIFF
--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -17,7 +17,7 @@
       "type": "string",
       "format": "radio",
       "title": "Python Version & Environment Isolation",
-      "default": null,
+      "default": "",
       "options": {
         "tooltip": "- **Isolated environment** takes a couple of seconds to start, but gives you the opportuninty to pick one of the latest versions of Python. It's also a safer choice as it prevents package collisions.\n- Non-isolated environment (used to be the default choice) might start a bit faster, but can lead to issues mentioned above. It will also become a subject to deprecation in the future.\n- We recommmend you **update the code regularly** to make sure it runs with the latest versions of all packages. This will help you avoid issues with abandoned packages and **security vulnerabilities**.",
         "enum_titles": [


### PR DESCRIPTION
> see the render() method in developer-portal-ui/src/scripts/modules/admin/containers /AppEdit.jsx

Just to add further context, the nulls are removed by design exactly here: https://github.com/keboola/developer-portal-ui/blob/0a8b157959fbb730d46b62b3d4dd5aa31554267f/src/scripts/modules/admin/containers/AppEdit.jsx#L52