### PR TITLE
Change for missing error details

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
         logging.error(error_msg)
         if len(exc.args) > 1:
             detail = truncate_message(str(exc.args[1]), MAX_DETAIL_LENGTH)
-            logging.error("Error details:", extra={"full_message": detail})
+            logging.error(f"Error details: {detail}")
         exit(1)
     except Exception as exc:
         logging.exception(exc)


### PR DESCRIPTION
Hotfix for error details under full_message instead directly in text output.

Tested: https://connection.europe-west3.gcp.keboola.com/admin/projects/558/queue/52852512