### PR TITLE
feat: Add support for private PyPI repositories

### DIFF
--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -99,6 +99,55 @@
         }
       }
     },
+    "private_pypi": {
+      "type": "object",
+      "title": "Private PyPI Repository (Optional)",
+      "propertyOrder": 55,
+      "options": {
+        "tooltip": "Configure a private PyPI repository (e.g., Artifactory, Nexus, or any PEP 503 compliant index) to install packages from. The private repository will be used as an additional index alongside the public PyPI."
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enable Private PyPI Repository",
+          "default": false,
+          "propertyOrder": 1
+        },
+        "url": {
+          "type": "string",
+          "title": "Repository URL",
+          "propertyOrder": 2,
+          "options": {
+            "tooltip": "The URL of the private PyPI repository (e.g., https://artifactory.example.com/api/pypi/pypi-local/simple/). Must be a PEP 503 compliant simple index URL.",
+            "dependencies": {
+              "enabled": true
+            }
+          }
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "propertyOrder": 3,
+          "options": {
+            "tooltip": "Username for authentication (optional for some repositories).",
+            "dependencies": {
+              "enabled": true
+            }
+          }
+        },
+        "#password": {
+          "type": "string",
+          "title": "Password / Token",
+          "propertyOrder": 4,
+          "options": {
+            "tooltip": "Password or API token for authentication.",
+            "dependencies": {
+              "enabled": true
+            }
+          }
+        }
+      }
+    },
     "git": {
       "type": "object",
       "title": "Git Repository Source Settings",

--- a/src/component.py
+++ b/src/component.py
@@ -76,9 +76,9 @@ class Component(ComponentBase):
         if self.parameters.source == SourceEnum.CODE:
             if "keboola.component" not in self.parameters.packages:
                 self.parameters.packages.insert(0, "keboola.component")
-            PackageInstaller.install_packages(self.parameters.packages)
+            PackageInstaller.install_packages(self.parameters.packages, self.parameters.private_pypi)
         else:
-            PackageInstaller.install_packages_for_repository(base_path)
+            PackageInstaller.install_packages_for_repository(base_path, self.parameters.private_pypi)
 
         self._merge_user_parameters()
 

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -50,6 +50,14 @@ class GitConfiguration:
 
 
 @dataclass
+class PrivatePyPIConfiguration:
+    enabled: bool = False
+    url: str = ""
+    username: str = ""
+    encrypted_password: str | None = None
+
+
+@dataclass
 class Configuration:
     source: SourceEnum = SourceEnum.CODE
     user_properties: dict[str, object] | list = field(default_factory=dict)
@@ -57,6 +65,7 @@ class Configuration:
     packages: list[str] = field(default_factory=list)
     code: str = ""
     git: GitConfiguration = field(default_factory=GitConfiguration)
+    private_pypi: PrivatePyPIConfiguration = field(default_factory=PrivatePyPIConfiguration)
 
     def __post_init__(self):
         if isinstance(self.user_properties, list):

--- a/src/package_installer.py
+++ b/src/package_installer.py
@@ -1,42 +1,81 @@
 import logging
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from subprocess_runner import SubprocessRunner
+
+if TYPE_CHECKING:
+    from configuration import PrivatePyPIConfiguration
 
 MSG_OK = "Installation successful."
 MSG_ERR = "Installation failed."
 
+PRIVATE_PYPI_INDEX_NAME = "private"
+
 
 class PackageInstaller:
     @staticmethod
-    def install_packages(packages: list[str]):
+    def _setup_private_pypi_env(private_pypi: "PrivatePyPIConfiguration | None") -> None:
+        """
+        Set up environment variables for private PyPI repository authentication.
+
+        Args:
+            private_pypi: Private PyPI configuration, or None if not configured.
+        """
+        if private_pypi is None or not private_pypi.enabled or not private_pypi.url:
+            return
+
+        logging.info("Configuring private PyPI repository: %s", private_pypi.url)
+
+        os.environ["UV_INDEX"] = f"{PRIVATE_PYPI_INDEX_NAME}={private_pypi.url}"
+
+        if private_pypi.username:
+            env_var_name = f"UV_INDEX_{PRIVATE_PYPI_INDEX_NAME.upper()}_USERNAME"
+            os.environ[env_var_name] = private_pypi.username
+
+        if private_pypi.encrypted_password:
+            env_var_name = f"UV_INDEX_{PRIVATE_PYPI_INDEX_NAME.upper()}_PASSWORD"
+            os.environ[env_var_name] = private_pypi.encrypted_password
+
+    @staticmethod
+    def install_packages(
+        packages: list[str],
+        private_pypi: "PrivatePyPIConfiguration | None" = None
+    ) -> None:
+        PackageInstaller._setup_private_pypi_env(private_pypi)
+
         for package in packages:
             logging.info("Installing package: %s...", package)
             args = ["uv", "pip", "install", package]
             SubprocessRunner.run(args, MSG_OK, MSG_ERR)
 
     @staticmethod
-    def install_packages_for_repository(repository_path: Path):
+    def install_packages_for_repository(
+        repository_path: Path,
+        private_pypi: "PrivatePyPIConfiguration | None" = None
+    ) -> None:
         """
         Install packages based on the given repository path.
         - If there is a pyproject.toml and a uv.lock file, run uv sync.
         - If there is a requirements.txt file, install packages from it using uv.
 
         Args:
-            repository_path (str): Path to the repository containing requirements.txt.
+            repository_path: Path to the repository containing requirements.txt.
+            private_pypi: Private PyPI configuration, or None if not configured.
         """
+        PackageInstaller._setup_private_pypi_env(private_pypi)
+
         pyproject_file = repository_path / "pyproject.toml"
         uv_lock_file = repository_path / "uv.lock"
         requirements_file = repository_path / "requirements.txt"
 
-        # Explicitly install keboola.component in case user didn't include in their dependencies file
-        PackageInstaller.install_packages(["keboola.component"])
+        PackageInstaller.install_packages(["keboola.component"], private_pypi)
 
         args = None
         if pyproject_file.exists() and uv_lock_file.exists():
             logging.info("Running uv sync...")
-            os.chdir(repository_path)  # it is currently impossible to pass custom uv.lock path
+            os.chdir(repository_path)
             args = ["uv", "sync", "--inexact"]
         elif requirements_file.exists():
             logging.info("Installing packages from requirements.txt...")


### PR DESCRIPTION
## Summary

Adds support for private PyPI repositories (e.g., Artifactory, Nexus) in the custom Python component. Users can now configure a private PyPI repository as an additional package index alongside the public PyPI.

**Configuration options added:**
- `enabled`: Toggle to enable/disable the feature
- `url`: Private PyPI repository URL (PEP 503 compliant simple index)
- `username`: Optional username for authentication
- `#password`: Encrypted password/token for authentication

The implementation uses uv's environment variables (`UV_INDEX`, `UV_INDEX_PRIVATE_USERNAME`, `UV_INDEX_PRIVATE_PASSWORD`) to configure the additional index and authentication.

## Review & Testing Checklist for Human

- [ ] **Verify UV_INDEX format**: Confirm that `UV_INDEX=private=<url>` is the correct format for uv to recognize an additional index. The uv docs suggest this should work but needs verification.
- [ ] **Test with actual private PyPI**: This has not been tested end-to-end with a real Artifactory/Nexus instance. Test with both authenticated and unauthenticated private repositories.
- [ ] **Verify encrypted password mapping**: The schema uses `#password` which should map to `encrypted_password` via the `encrypted_keys` function - verify this works correctly.
- [ ] **Check `uv sync` behavior**: When using Git source with `pyproject.toml`/`uv.lock`, verify that `uv sync --inexact` respects the `UV_INDEX` environment variable.

**Recommended test plan:**
1. Configure a test private PyPI repository (or use an existing Artifactory instance)
2. Create a component configuration with `private_pypi.enabled=true` and valid credentials
3. Test installing a package that only exists in the private repository
4. Verify both CODE and GIT source modes work correctly

### Notes

Note: `_setup_private_pypi_env` is called redundantly in `install_packages_for_repository` (once directly, once via `install_packages`). This is harmless but could be cleaned up.

**Link to Devin run:** https://app.devin.ai/sessions/a858822356fb4c66962081b4b638ee82
**Requested by:** Vojta Tuma (@yustme)

## Release Notes
**Justification, description**

Adds support for private PyPI repositories to enable users to install packages from internal package indexes like Artifactory or Nexus.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk - feature is opt-in and disabled by default. Existing configurations without `private_pypi` will continue to work unchanged.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A