### PR TITLE
Python 3.14 is no longer RC 🐍 🥳

### DIFF
--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -21,9 +21,9 @@
       "options": {
         "tooltip": "- **Isolated environment** takes a couple of seconds to start, but gives you the opportuninty to pick one of the latest versions of Python. It's also a safer choice as it prevents package collisions.\n- Non-isolated environment (used to be the default choice) might start a bit faster, but can lead to issues mentioned above. It will also become a subject to deprecation in the future.\n- We recommmend you **update the code regularly** to make sure it runs with the latest versions of all packages. This will help you avoid issues with abandoned packages and **security vulnerabilities**.",
         "enum_titles": [
-          "Python 3.14 RC – Isolated environment (just the packages of your choice)",
-          "Python 3.13 – Isolated environment (just the packages of your choice) – This is the recommended choice 🐙",
-          "Python 3.12 – Isolated environment (just the packages of your choice)",
+          "Python 3.14 – Isolated environment (just the packages of your choice) – This is the recommended choice 🐙",
+          "Python 3.13 – Isolated environment",
+          "Python 3.12 – Isolated environment",
           "Python 3.10 – Shared environment (contains many pre-installed packages in legacy versions) – This used to be the default choice"
         ]
       },


### PR DESCRIPTION
Python 3.14 has already been stable for more than half a year and since we always pack the latest release in our images, it's already "not-just-a-RC" for a long time. Most well-maintained mainstream packages already support it, so I think it's also the right time to update the recommendation. 🙂